### PR TITLE
Translated Now shortcut label

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,4 @@
 # English strings go here for Rails i18n
 en:
   show_shortcut: "Display Now shortcut"
+  now_label: "Now"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,2 +1,3 @@
 fr:
   show_shortcut: "Afficher le raccourci 'Maintenant'"
+  now_label: "Maintenant"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,0 +1,4 @@
+# Italian strings go here for Rails i18n
+it:
+  show_shortcut: 'Mostra la scorciatoia "Adesso"'
+  now_label: "Adesso"

--- a/lib/redmine_datetime_custom_field/field_format_patch.rb
+++ b/lib/redmine_datetime_custom_field/field_format_patch.rb
@@ -21,7 +21,7 @@ module Redmine
       def edit_tag(view, tag_id, tag_name, custom_value, options = {})
         edit_tag = view.text_field_tag(tag_name, custom_value.value, options.merge(:id => tag_id, :size => 15)) +
           view.calendar_for(tag_id, custom_value.custom_field.show_hours == '1')
-        edit_tag += view.link_to('maintenant', '#',
+        edit_tag += view.link_to(::I18n.t(:now_label), '#',
                                  onclick: "nowShortcut(this.dataset.cfId, " + custom_value.custom_field.show_hours + "); return false",
                                  data: { cf_id: custom_value.custom_field.id },
                                  class: "now_shortcut") if custom_value.custom_field.show_shortcut == '1'


### PR DESCRIPTION
* Implemented localization for "Now" shortcut, formerly displayed as `maintenant` regardless of selected locale.
* Added Italian localization.