### PR TITLE
Remove Select2

### DIFF
--- a/assets/javascripts/datetime_custom_field.js
+++ b/assets/javascripts/datetime_custom_field.js
@@ -31,35 +31,6 @@ function addFilter(field, operator, values) {
       $(this).attr('disabled', true);
     }
   });
-
-  // Patch
-  addSelect2ToSelectTags()
-}
-
-function toggleMultiSelect(el) {
-  if (el.attr('multiple')) {
-    el.removeAttr('multiple');
-    el.attr('size', 1);
-  } else {
-    el.attr('multiple', true);
-    if (el.children().length > 10)
-      el.attr('size', 10);
-    else
-      el.attr('size', 4);
-  }
-  // Patch
-  addSelect2ToSelectTags()
-}
-
-function addSelect2ToSelectTags() {
-  $(document).ready(function(){
-    if ((typeof $().select2) === 'function') {
-      $('#filters select.value').select2({
-        containerCss: {width: '300px', minwidth: '300px'},
-        width: 'style'
-      })
-    }
-  })
 }
 
 function buildDateTimeFilterRow(field, operator, values) {


### PR DESCRIPTION
### Réponse au ticket 172792 :
- Déplacement de tout le code qui concerne le composant `select2 `depuis le plugin `redmine_datetime_custom_field` vers le plugin `redmine_tiny_features`